### PR TITLE
Specify libraries after the object files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LIBS   += -lssl -lcrypto -lgetdns
 endif
 
 all: main.o ocsp-stapling.o dnssec-chain-extension.o
-	$(CC) $(CFLAGS) $(LDFLAGS) $(LIBS) -o openssl-demo-server $^
+	$(CC) $(CFLAGS) $(LDFLAGS) -o openssl-demo-server $^ $(LIBS)
 
 clean:
 	rm -f openssl-demo-server *.o


### PR DESCRIPTION
This is needed for the GNU linker.  From the man page:

       -l namespec
       --library=namespec
           Add the archive or object file specified by namespec to the list of files to
           link.  This option may be used any number of times.

    <snap>

           The linker will search an archive only once, at the location where it is
           specified on the command line.  If the archive defines a symbol which was
           undefined in some object which appeared before the archive on the command
           line, the linker will include the appropriate file(s) from the archive.
           However, an undefined symbol in an object appearing later on the command
           line will not cause the linker to search the archive again.